### PR TITLE
Adding onsale date filter to events v2 discovery api

### DIFF
--- a/products-and-docs/apis/discovery/v2/index.md
+++ b/products-and-docs/apis/discovery/v2/index.md
@@ -83,6 +83,8 @@ discovery/{version}/events.{format}
 | `size`   | The number of events returned in the API response. | string            |       "10"       | No      |
 | `page`   | The page for paginating through the results. | string            |       "1"       | No      |
 | `sort`   | The search sort criteria. Values: "", "eventDate,desc", "eventDate,asc", "name,desc", "name,asc". | string            |              | No      |
+| `onsaleStartDateTime`   | Include events going onsale after this date. | string            |       "2017-01-01T00:00:00Z"       | No      |
+| `onsaleEndDateTime`   | Include events going onsale before this date. | string            |       "2017-01-01T00:00:00Z"       | No      |
 
 
 ### Response structure:


### PR DESCRIPTION
Adding onsale date filter to the events discovery api - This was released to production yesterday.
