### PR TITLE
Added max page size to Search Events docs

### DIFF
--- a/products-and-docs/apis/discovery/v2/index.md
+++ b/products-and-docs/apis/discovery/v2/index.md
@@ -115,7 +115,7 @@ discovery/{version}/events.{format}
 | `includeTBA`   | 	Whether or not to return events with dates to be announced (TBA). Default is 'no', TBA events are not returned. | string            |       "yes&#124;no&#124;only"       | No      |
 | `includeTBD`   | Whether or not to return events with dates to be determined (TBD). Default is 'no', TBD events are not returned. | string            |       "yes&#124;no&#124;only"       | No      |
 | `includeTest`   | Whether or not to return test events. Default is 'no', test events are not returned. | string            |       "yes&#124;no&#124;only"       | No      |
-| `size`   | The number of events returned in the API response. | string            |       "10"       | No      |
+| `size`   | The number of events returned in the API response. (Max 500) | string            |       "10"       | No      |
 | `page`   | The page for paginating through the results. | string            |       "1"       | No      |
 | `sort`   | The search sort criteria. Values: "", "eventDate,date.desc", "eventDate,date.asc", "name,date.desc", "name,date.asc". | string            |              | No      |
 | `onsaleStartDateTime`   | Include events going onsale after this date. | string            |       "2017-01-01T00:00:00Z"       | No      |


### PR DESCRIPTION
Since it was not noted in the docs what the max number of events could be returned in a single call from Search Events, I added it to the docs.
