### PR TITLE
Enable Checkout Widget in navigation (and fix typo)

### DIFF
--- a/_includes/partials/expanded-menu-header.html
+++ b/_includes/partials/expanded-menu-header.html
@@ -82,9 +82,9 @@
                     <h4>WIDGETS</h4>
                 </a>
                 <ul>
-<!--                     <li>
+                    <li>
                         <a href="/products-and-docs/widgets/checkout/">Checkout Widget</a>
-                    </li> -->
+                    </li>
                     <li>
                         <a href="/products-and-docs/widgets/event-discovery/">Event Discovery Widget</a>
                     </li>

--- a/_includes/pd-side-menu.html
+++ b/_includes/pd-side-menu.html
@@ -316,7 +316,7 @@
         <h4><a href="/products-and-docs/widgets/" {% if page.categories[0] == "documentation" and page.categories[1] == "widgets" %} class="active" {% endif %} >Widgets</a></h4>
         {% if page.categories[0] == "documentation" and page.categories[1] == "widgets" %}
             <ul class="categories menu-highlight">
-                <!-- <li><a href="/products-and-docs/widgets/checkout/">Checkout Widget</a></li> -->
+                <li><a href="/products-and-docs/widgets/checkout/">Checkout Widget</a></li>
                 <li><a href="/products-and-docs/widgets/event-discovery/">Event Discovery Widget</a></li>
                 <li><a href="/products-and-docs/widgets/countdown/">Countdown Widget</a></li>
                 <li><a href="/products-and-docs/widgets/calendar/">Calendar Widget</a></li>

--- a/products-and-docs/widgets/checkout/index.md
+++ b/products-and-docs/widgets/checkout/index.md
@@ -46,7 +46,7 @@ Grab a small code snippet to insert into your website
           <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;script </span><span class="na">type=</span><span class="s">"text/javascript"</span> <span class="na">src=</span><span class="s">"https://embed.ticketmaster.com/tm.js"</span><span class="nt">&gt;&lt;/script&gt;</span></code></pre></figure>
 
           <ul>
-            <li><strong>Step 2:</strong> Next, paste the snippet within the <em>&lt;head&gt;</em> tag of your website.  For example:</li>
+            <li><strong>Step 2:</strong> Next, paste the snippet within the <em>&lt;head&gt;</em> tag of your website.</li>
           </ul>
 
 <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;head&gt;</span>

--- a/products-and-docs/widgets/index.md
+++ b/products-and-docs/widgets/index.md
@@ -53,11 +53,11 @@ directly on your website at no additional cost.
 
 {% endcapture %}
 
-<!--
+
 <div class="widget_box widget_box__checkout" markdown="1">
 {{checkout-widget}}
 </div>
- -->
+
 <div class="widget_box widget_box__discovery" markdown="1">
 {{discovery-widget}}
 </div>


### PR DESCRIPTION
Enables navigation links, and fixes a small typo in Checkout Widget documentation.
